### PR TITLE
Add ability to store vary headers

### DIFF
--- a/mee-extension-lib/main.ts
+++ b/mee-extension-lib/main.ts
@@ -11,6 +11,7 @@ import {
   setMySignalsEnabled,
   setDomainMsConfirmed,
   setDomainVaryHeaders,
+  setDomainHighEntropyHints,
   getMsConfirmedDomains,
 } from "./src/store";
 import { getDomainFromUrl, getRegDomain, getRegDomains } from "./src/string";
@@ -433,5 +434,6 @@ export {
   setMySignalsEnabled,
   setDomainMsConfirmed,
   setDomainVaryHeaders,
+  setDomainHighEntropyHints,
   getMsConfirmedDomains,
 };

--- a/mee-extension-lib/main.ts
+++ b/mee-extension-lib/main.ts
@@ -10,6 +10,7 @@ import {
   getMySignalsEnabled,
   setMySignalsEnabled,
   setDomainMsConfirmed,
+  setDomainVaryHeaders,
   getMsConfirmedDomains,
 } from "./src/store";
 import { getDomainFromUrl, getRegDomain, getRegDomains } from "./src/string";
@@ -431,5 +432,6 @@ export {
   getMySignalsEnabled,
   setMySignalsEnabled,
   setDomainMsConfirmed,
+  setDomainVaryHeaders,
   getMsConfirmedDomains,
 };

--- a/mee-extension-lib/src/store.ts
+++ b/mee-extension-lib/src/store.ts
@@ -1,5 +1,5 @@
 export function openDB(): IDBOpenDBRequest {
-  return indexedDB.open("MeeWebExtensionDB", 7);
+  return indexedDB.open("MeeWebExtensionDB", 8);
 }
 
 export function initDB() {
@@ -23,6 +23,20 @@ export function initDB() {
     }
     if (!db.objectStoreNames.contains("settings")) {
       db.createObjectStore("settings", { keyPath: "key" });
+    }
+    if (event.oldVersion < 8 && db.objectStoreNames.contains("domains")) {
+      const transaction = (event.target as IDBOpenDBRequest).transaction!;
+      const store = transaction.objectStore("domains");
+      store.openCursor().onsuccess = (e: any) => {
+        const cursor: IDBCursorWithValue = e.target.result;
+        if (cursor) {
+          const row = cursor.value;
+          if (!("varyHeaders" in row)) {
+            cursor.update({ ...row, varyHeaders: [] });
+          }
+          cursor.continue();
+        }
+      };
     }
   };
 }
@@ -83,6 +97,7 @@ interface AddDBRow {
   wellknown: boolean;
   enabled: boolean;
   msConfirmed?: boolean;
+  varyHeaders?: string[];
   id?: number;
 }
 interface DBRow extends AddDBRow {
@@ -112,8 +127,9 @@ export function addRowToDB(data: AddDBRow) {
           ...old_data,
           enabled: old_data ? old_data.enabled : data.enabled,
           wellknown: data.wellknown,
+          varyHeaders: data.varyHeaders ?? old_data.varyHeaders ?? [],
         }
-      : { ...data, msConfirmed: data.msConfirmed ?? false };
+      : { ...data, msConfirmed: data.msConfirmed ?? false, varyHeaders: data.varyHeaders ?? [] };
 
     const requestUpdate = objectStore.put(new_data);
     requestUpdate.onerror = (event) => {
@@ -316,6 +332,48 @@ export async function setDomainMsConfirmed(
           putRequest.onerror = () => {
             db.close();
             reject("Error updating msConfirmed");
+          };
+        } else {
+          db.close();
+          resolve();
+        }
+      };
+      request_get_all.onerror = () => {
+        db.close();
+        reject("Error reading domains");
+      };
+    };
+  });
+}
+
+export async function setDomainVaryHeaders(
+  domain: string,
+  headers: string[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = openDB();
+    request.onerror = () => {
+      reject("Error in openDB");
+    };
+    request.onsuccess = async function (event) {
+      const db = (event.target as IDBOpenDBRequest).result;
+      const transaction = db.transaction(["domains"], "readwrite");
+      const objectStore = transaction.objectStore("domains");
+      const request_get_all = objectStore.getAll();
+
+      request_get_all.onsuccess = (event: any) => {
+        const records: DBRow[] = event.target.result;
+        const domainRecord = records.find((r) => r.domain === domain);
+        if (domainRecord) {
+          const updated = { ...domainRecord, varyHeaders: headers };
+          const putRequest = objectStore.put(updated);
+          putRequest.onsuccess = () => {
+            db.close();
+            resolve();
+          };
+          putRequest.onerror = () => {
+            db.close();
+            reject("Error updating varyHeaders");
           };
         } else {
           db.close();

--- a/mee-extension-lib/src/store.ts
+++ b/mee-extension-lib/src/store.ts
@@ -1,5 +1,5 @@
 export function openDB(): IDBOpenDBRequest {
-  return indexedDB.open("MeeWebExtensionDB", 8);
+  return indexedDB.open("MeeWebExtensionDB", 9);
 }
 
 export function initDB() {
@@ -24,15 +24,24 @@ export function initDB() {
     if (!db.objectStoreNames.contains("settings")) {
       db.createObjectStore("settings", { keyPath: "key" });
     }
-    if (event.oldVersion < 8 && db.objectStoreNames.contains("domains")) {
+    if (event.oldVersion < 9 && db.objectStoreNames.contains("domains")) {
       const transaction = (event.target as IDBOpenDBRequest).transaction!;
       const store = transaction.objectStore("domains");
       store.openCursor().onsuccess = (e: any) => {
         const cursor: IDBCursorWithValue = e.target.result;
         if (cursor) {
           const row = cursor.value;
+          let needsUpdate = false;
           if (!("varyHeaders" in row)) {
-            cursor.update({ ...row, varyHeaders: [] });
+            row.varyHeaders = [];
+            needsUpdate = true;
+          }
+          if (!("highEntropyHints" in row)) {
+            row.highEntropyHints = [];
+            needsUpdate = true;
+          }
+          if (needsUpdate) {
+            cursor.update(row);
           }
           cursor.continue();
         }
@@ -98,6 +107,7 @@ interface AddDBRow {
   enabled: boolean;
   msConfirmed?: boolean;
   varyHeaders?: string[];
+  highEntropyHints?: string[];
   id?: number;
 }
 interface DBRow extends AddDBRow {
@@ -128,8 +138,9 @@ export function addRowToDB(data: AddDBRow) {
           enabled: old_data ? old_data.enabled : data.enabled,
           wellknown: data.wellknown,
           varyHeaders: data.varyHeaders ?? old_data.varyHeaders ?? [],
+          highEntropyHints: data.highEntropyHints ?? old_data.highEntropyHints ?? [],
         }
-      : { ...data, msConfirmed: data.msConfirmed ?? false, varyHeaders: data.varyHeaders ?? [] };
+      : { ...data, msConfirmed: data.msConfirmed ?? false, varyHeaders: data.varyHeaders ?? [], highEntropyHints: data.highEntropyHints ?? [] };
 
     const requestUpdate = objectStore.put(new_data);
     requestUpdate.onerror = (event) => {
@@ -374,6 +385,48 @@ export async function setDomainVaryHeaders(
           putRequest.onerror = () => {
             db.close();
             reject("Error updating varyHeaders");
+          };
+        } else {
+          db.close();
+          resolve();
+        }
+      };
+      request_get_all.onerror = () => {
+        db.close();
+        reject("Error reading domains");
+      };
+    };
+  });
+}
+
+export async function setDomainHighEntropyHints(
+  domain: string,
+  hints: string[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = openDB();
+    request.onerror = () => {
+      reject("Error in openDB");
+    };
+    request.onsuccess = async function (event) {
+      const db = (event.target as IDBOpenDBRequest).result;
+      const transaction = db.transaction(["domains"], "readwrite");
+      const objectStore = transaction.objectStore("domains");
+      const request_get_all = objectStore.getAll();
+
+      request_get_all.onsuccess = (event: any) => {
+        const records: DBRow[] = event.target.result;
+        const domainRecord = records.find((r) => r.domain === domain);
+        if (domainRecord) {
+          const updated = { ...domainRecord, highEntropyHints: hints };
+          const putRequest = objectStore.put(updated);
+          putRequest.onsuccess = () => {
+            db.close();
+            resolve();
+          };
+          putRequest.onerror = () => {
+            db.close();
+            reject("Error updating highEntropyHints");
           };
         } else {
           db.close();

--- a/mee-extension-lib/vite.config.ts
+++ b/mee-extension-lib/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
   },
   plugins: [
-    dts(),
+    //dts(),
     viteStaticCopy({
       targets: copy_targets,
     }),

--- a/mee-extension-lib/vite.config.ts
+++ b/mee-extension-lib/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
   },
   plugins: [
-    //dts(),
+    dts(),
     viteStaticCopy({
       targets: copy_targets,
     }),

--- a/src/background.ts
+++ b/src/background.ts
@@ -138,8 +138,8 @@ async function probeMySignals(domain: string): Promise<ProbeResult> {
     const criticalMs = response.headers.get("Critical-MS");
     const acceptedMs = response.headers.get("Accepted-MS");
     const confirmed =
-      (criticalMs !== null && criticalMs.trim().toUpperCase() === "GPC") ||
-      (acceptedMs !== null && acceptedMs.trim().toUpperCase() === "GPC");
+      (criticalMs !== null && criticalMs.trim().toUpperCase().split(";").includes("GPC")) ||
+      (acceptedMs !== null && acceptedMs.trim().toUpperCase().split(";").includes("GPC"));
 
     const varyRaw = response.headers.get("Vary");
     const varyHeaders = varyRaw

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,6 +11,7 @@ import {
   getMySignalsEnabled,
   switchMySignalsMode,
   handleProbeResult,
+  setDomainVaryHeaders,
 } from "mee-extension-lib";
 
 import config from "./config";
@@ -41,11 +42,12 @@ function afterDownloadWellknown(
       enabled: true,
     });
 
-    chrome.runtime.onMessage.addListener((message) => {
+    chrome.runtime.onMessage.addListener(async (message) => {
       if (message.msg === "POPUP_LOADED") {
+        const domainData = await getDomainData(domain);
         chrome.runtime.sendMessage({
           msg: "SEND_WELLKNOWN_TO_POPUP",
-          data: { domain, wellknownData },
+          data: { domain, wellknownData, varyHeaders: domainData?.varyHeaders ?? [] },
         });
       }
     });
@@ -101,7 +103,12 @@ async function onCheckEnabledMessageHandled(
   sendResponse({ enabled });
 }
 
-async function probeMySignals(domain: string): Promise<boolean> {
+interface ProbeResult {
+  confirmed: boolean;
+  varyHeaders: string[];
+}
+
+async function probeMySignals(domain: string): Promise<ProbeResult> {
   try {
     const response = await fetch(`https://${domain}/`, {
       method: "HEAD",
@@ -110,14 +117,19 @@ async function probeMySignals(domain: string): Promise<boolean> {
     });
 
     const criticalMs = response.headers.get("Critical-MS");
-    const acceptedNs = response.headers.get("Accepted-NS");
-
-    return (
+    const acceptedMs = response.headers.get("Accepted-MS");
+    const confirmed =
       (criticalMs !== null && criticalMs.trim().toUpperCase() === "GPC") ||
-      (acceptedNs !== null && acceptedNs.trim().toUpperCase() === "GPC")
-    );
+      (acceptedMs !== null && acceptedMs.trim().toUpperCase() === "GPC");
+
+    const varyRaw = response.headers.get("Vary");
+    const varyHeaders = varyRaw
+      ? varyRaw.split(",").map((v) => v.trim()).filter(Boolean)
+      : [];
+
+    return { confirmed, varyHeaders };
   } catch {
-    return false;
+    return { confirmed: false, varyHeaders: [] };
   }
 }
 
@@ -178,7 +190,10 @@ chrome.runtime.onMessage.addListener(
               if (mySignalsOn) {
                 const domainData = await getDomainData(domain);
                 if (domainData && domainData.enabled && !domainData.msConfirmed) {
-                  const confirmed = await probeMySignals(domain);
+                  const { confirmed, varyHeaders } = await probeMySignals(domain);
+                  if (varyHeaders.length > 0) {
+                    await setDomainVaryHeaders(domain, varyHeaders);
+                  }
                   if (confirmed) {
                     await handleProbeResult(
                       domain,

--- a/src/background.ts
+++ b/src/background.ts
@@ -12,6 +12,7 @@ import {
   switchMySignalsMode,
   handleProbeResult,
   setDomainVaryHeaders,
+  setDomainHighEntropyHints,
 } from "mee-extension-lib";
 
 import config from "./config";
@@ -47,7 +48,12 @@ function afterDownloadWellknown(
         const domainData = await getDomainData(domain);
         chrome.runtime.sendMessage({
           msg: "SEND_WELLKNOWN_TO_POPUP",
-          data: { domain, wellknownData, varyHeaders: domainData?.varyHeaders ?? [] },
+          data: {
+            domain,
+            wellknownData,
+            varyHeaders: domainData?.varyHeaders ?? [],
+            highEntropyHints: domainData?.highEntropyHints ?? [],
+          },
         });
       }
     });
@@ -103,9 +109,22 @@ async function onCheckEnabledMessageHandled(
   sendResponse({ enabled });
 }
 
+const HIGH_ENTROPY_HINTS = [
+  "Sec-CH-UA-Platform",
+  "Sec-CH-UA-Platform-Version",
+  "Sec-CH-UA-Arch",
+  "Sec-CH-UA-Model",
+  "Sec-CH-UA-Full-Version-List",
+  "Device-Memory",
+  "Downlink",
+  "RTT",
+  "ECT",
+];
+
 interface ProbeResult {
   confirmed: boolean;
   varyHeaders: string[];
+  highEntropyHints: string[];
 }
 
 async function probeMySignals(domain: string): Promise<ProbeResult> {
@@ -127,9 +146,19 @@ async function probeMySignals(domain: string): Promise<ProbeResult> {
       ? varyRaw.split(",").map((v) => v.trim()).filter(Boolean)
       : [];
 
-    return { confirmed, varyHeaders };
+    const acceptChRaw = response.headers.get("Accept-CH");
+    const highEntropyHints = acceptChRaw
+      ? acceptChRaw
+          .split(",")
+          .map((v) => v.trim())
+          .filter((hint) =>
+            HIGH_ENTROPY_HINTS.some((h) => h.toLowerCase() === hint.toLowerCase())
+          )
+      : [];
+
+    return { confirmed, varyHeaders, highEntropyHints };
   } catch {
-    return { confirmed: false, varyHeaders: [] };
+    return { confirmed: false, varyHeaders: [], highEntropyHints: [] };
   }
 }
 
@@ -190,9 +219,12 @@ chrome.runtime.onMessage.addListener(
               if (mySignalsOn) {
                 const domainData = await getDomainData(domain);
                 if (domainData && domainData.enabled && !domainData.msConfirmed) {
-                  const { confirmed, varyHeaders } = await probeMySignals(domain);
+                  const { confirmed, varyHeaders, highEntropyHints } = await probeMySignals(domain);
                   if (varyHeaders.length > 0) {
                     await setDomainVaryHeaders(domain, varyHeaders);
+                  }
+                  if (highEntropyHints.length > 0) {
+                    await setDomainHighEntropyHints(domain, highEntropyHints);
                   }
                   if (confirmed) {
                     await handleProbeResult(

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -165,6 +165,66 @@ input:checked + .slider:before {
   color: #3b5b63;
 }
 
+.vary-badge-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.vary-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #22c55e;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: default;
+  user-select: none;
+}
+
+.vary-tooltip {
+  display: none;
+  position: absolute;
+  right: 32px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(30, 41, 59, 0.5);
+  color: #f8fafc;
+  font-family: "Public Sans";
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 6px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  z-index: 10;
+  pointer-events: none;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 4px;
+  max-width: 300px;
+}
+
+.vary-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -6px;
+  transform: translateY(-50%);
+  border-width: 6px 0 6px 6px;
+  border-style: solid;
+  border-color: transparent transparent transparent rgba(30, 41, 59, 0.5);
+}
+
+
+.vary-badge-wrapper:hover .vary-tooltip {
+  display: flex;
+}
+
 @font-face {
   font-family: Public Sans;
   font-style: normal;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -225,6 +225,79 @@ input:checked + .slider:before {
   display: flex;
 }
 
+.hints-row {
+  border-bottom: 1px solid #cbd5e1;
+  justify-content: space-between;
+  
+}
+
+.hints-text {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  color: #92400e;
+}
+
+.hints-badge-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.hints-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #f59e0b;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: default;
+  user-select: none;
+}
+
+.hints-tooltip {
+  display: none;
+  position: absolute;
+  left: 32px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(30, 41, 59, 0.5);
+  color: #f8fafc;
+  font-family: "Public Sans";
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 6px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  z-index: 10;
+  pointer-events: none;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 300px;
+}
+
+.hints-tooltip::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -6px;
+  transform: translateY(-50%);
+  border-width: 6px 6px 6px 0;
+  border-style: solid;
+  border-color: transparent rgba(30, 41, 59, 0.5) transparent transparent;
+}
+
+.hints-badge-wrapper:hover .hints-tooltip {
+  display: flex;
+}
+
 @font-face {
   font-family: Public Sans;
   font-style: normal;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -204,9 +204,7 @@ input:checked + .slider:before {
   z-index: 10;
   pointer-events: none;
   flex-direction: row;
-  flex-wrap: wrap;
-  gap: 4px;
-  max-width: 300px;
+  gap: 8px;
 }
 
 .vary-tooltip::after {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -80,8 +80,15 @@
                     <span class="slider"></span>
                 </label>
             </div>
-            <div class="row vary-row" id="vary-status-row" style="display:none">
-                <span class="text">Server varies response by request headers</span>
+            <div
+                class="row vary-row hints-row"
+                id="vary-status-row"
+                style="display: none"
+            >
+                <div class="hints-badge-wrapper">
+                    <span class="hints-badge" id="hints-badge">!</span>
+                    <div class="hints-tooltip" id="hints-tooltip"></div>
+                </div>
                 <div class="vary-badge-wrapper">
                     <span class="vary-badge" id="vary-badge">✓</span>
                     <div class="vary-tooltip" id="vary-tooltip"></div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -80,6 +80,13 @@
                     <span class="slider"></span>
                 </label>
             </div>
+            <div class="row vary-row" id="vary-status-row" style="display:none">
+                <span class="text">Server varies response by request headers</span>
+                <div class="vary-badge-wrapper">
+                    <span class="vary-badge" id="vary-badge">✓</span>
+                    <div class="vary-tooltip" id="vary-tooltip"></div>
+                </div>
+            </div>
         </div>
     </body>
 </html>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -87,14 +87,32 @@ async function checkMySignalsState() {
   }
 }
 
+async function updateVaryStatus(varyHeaders: string[]) {
+  const mySignalsOn = await getMySignalsEnabled();
+  const varyRow = document.getElementById("vary-status-row");
+  const tooltip = document.getElementById("vary-tooltip");
+
+  const shouldShow = mySignalsOn && varyHeaders.length > 0;
+  if (varyRow) varyRow.style.display = shouldShow ? "flex" : "none";
+  if (tooltip) {
+    tooltip.replaceChildren(); // or tooltip.textContent = "";
+    varyHeaders.forEach((header) => {
+      const span = document.createElement("span");
+      span.textContent = header; // textContent automatically escapes all HTML characters
+      tooltip.appendChild(span);
+    });
+  }
+}
+
 chrome.runtime.onMessage.addListener(async function (message, _, __) {
   if (message.msg === "SEND_WELLKNOWN_TO_POPUP") {
     const parsedDomain = await getCurrentParsedDomain();
-    let { domain } = message.data;
+    let { domain, varyHeaders } = message.data;
 
     if (parsedDomain && domain === parsedDomain) {
       checkDomain(parsedDomain);
       checkAlert(parsedDomain);
+      updateVaryStatus(varyHeaders ?? []);
     }
   }
 });
@@ -111,6 +129,9 @@ document.addEventListener("DOMContentLoaded", async (_) => {
     checkAlert(parsedDomain);
     checkEnabledExtension();
     checkMySignalsState();
+    getDomainData(parsedDomain).then((data) =>
+      updateVaryStatus(data?.varyHeaders ?? [])
+    );
   } else {
     changeDisableSlider("slider-extension-switch", true);
     changeDisableSlider("slider-domain-switch", true);
@@ -163,4 +184,9 @@ document
       msg: "TOGGLE_MYSIGNALS",
     });
     await checkMySignalsState();
+    const parsedDomain = await getCurrentParsedDomain();
+    if (parsedDomain) {
+      const domainData = await getDomainData(parsedDomain);
+      await updateVaryStatus(domainData?.varyHeaders ?? []);
+    }
   });

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -95,10 +95,27 @@ async function updateVaryStatus(varyHeaders: string[]) {
   const shouldShow = mySignalsOn && varyHeaders.length > 0;
   if (varyRow) varyRow.style.display = shouldShow ? "flex" : "none";
   if (tooltip) {
-    tooltip.replaceChildren(); // or tooltip.textContent = "";
+    tooltip.replaceChildren();
     varyHeaders.forEach((header) => {
       const span = document.createElement("span");
-      span.textContent = header; // textContent automatically escapes all HTML characters
+      span.textContent = header;
+      tooltip.appendChild(span);
+    });
+  }
+}
+
+async function updateHintsStatus(highEntropyHints: string[]) {
+  const mySignalsOn = await getMySignalsEnabled();
+  const hintsRow = document.getElementById("hints-status-row");
+  const tooltip = document.getElementById("hints-tooltip");
+
+  const shouldShow = mySignalsOn && highEntropyHints.length > 0;
+  if (hintsRow) hintsRow.style.display = shouldShow ? "flex" : "none";
+  if (tooltip) {
+    tooltip.replaceChildren();
+    highEntropyHints.forEach((hint) => {
+      const span = document.createElement("span");
+      span.textContent = hint;
       tooltip.appendChild(span);
     });
   }
@@ -107,12 +124,13 @@ async function updateVaryStatus(varyHeaders: string[]) {
 chrome.runtime.onMessage.addListener(async function (message, _, __) {
   if (message.msg === "SEND_WELLKNOWN_TO_POPUP") {
     const parsedDomain = await getCurrentParsedDomain();
-    let { domain, varyHeaders } = message.data;
+    let { domain, varyHeaders, highEntropyHints } = message.data;
 
     if (parsedDomain && domain === parsedDomain) {
       checkDomain(parsedDomain);
       checkAlert(parsedDomain);
       updateVaryStatus(varyHeaders ?? []);
+      updateHintsStatus(highEntropyHints ?? []);
     }
   }
 });
@@ -129,9 +147,10 @@ document.addEventListener("DOMContentLoaded", async (_) => {
     checkAlert(parsedDomain);
     checkEnabledExtension();
     checkMySignalsState();
-    getDomainData(parsedDomain).then((data) =>
-      updateVaryStatus(data?.varyHeaders ?? [])
-    );
+    getDomainData(parsedDomain).then((data) => {
+      updateVaryStatus(data?.varyHeaders ?? []);
+      updateHintsStatus(data?.highEntropyHints ?? []);
+    });
   } else {
     changeDisableSlider("slider-extension-switch", true);
     changeDisableSlider("slider-domain-switch", true);
@@ -188,5 +207,6 @@ document
     if (parsedDomain) {
       const domainData = await getDomainData(parsedDomain);
       await updateVaryStatus(domainData?.varyHeaders ?? []);
+      await updateHintsStatus(domainData?.highEntropyHints ?? []);
     }
   });


### PR DESCRIPTION
Functionality to storing and display 'Vary' headers from HTTP responses. This information helps users understand how servers adapt their content based on request headers, improving privacy signaling.
Works only when MySignals mode is enabled.

Example:
![vary_headers](https://github.com/user-attachments/assets/ac90931f-9da5-460e-bab1-92251d545471)


