### PR TITLE
Add unit tests for MySignals probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@
 ```sh
 pnpm run test:chrome
 ```
+
+### For unit testing 
+
+```sh
+pnpm run test:unit
+```

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "build-lib": "cd mee-extension-lib && pnpm build",
     "build": "pnpm build-lib && run-p build:*",
     "build:chrome": "VITE_BROWSER=chrome vite build && VITE_BROWSER=chrome APP_FILE=content vite build && VITE_BROWSER=chrome APP_FILE=popup vite build && VITE_BROWSER=chrome APP_FILE=options vite build",
-    "test": "run-p test:*",
-    "test:chrome": "web-ext run --source-dir ./dist/chrome --target=chromium --start-url https://globalprivacycontrol.org --start-url https://global-privacy-control.glitch.me"
+    "test": "pnpm test:chrome",
+    "test:chrome": "web-ext run --source-dir ./dist/chrome --target=chromium --start-url https://globalprivacycontrol.org --start-url https://global-privacy-control.glitch.me",
+    "test:unit": "vitest run"
   },
   "author": "",
   "license": "ISC",
@@ -23,6 +24,7 @@
     "typescript": "^5.4.5",
     "vite": "^4.3.3",
     "vite-plugin-static-copy": "^0.14.0",
+    "vitest": "^1.6.0",
     "web-ext": "^7.8.0"
   },
   "dependencies": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -17,6 +17,7 @@ import {
 
 import config from "./config";
 import { getSDAData, parseTaxonomyRecords } from "./sda-profile";
+import { probeMySignals } from "./mysignals-probe";
 
 initDB();
 
@@ -107,59 +108,6 @@ async function onCheckEnabledMessageHandled(
   const enabled =
     message.url && !disable_domains.includes(message.url) && enabledExtension;
   sendResponse({ enabled });
-}
-
-const HIGH_ENTROPY_HINTS = [
-  "Sec-CH-UA-Platform",
-  "Sec-CH-UA-Platform-Version",
-  "Sec-CH-UA-Arch",
-  "Sec-CH-UA-Model",
-  "Sec-CH-UA-Full-Version-List",
-  "Device-Memory",
-  "Downlink",
-  "RTT",
-  "ECT",
-];
-
-interface ProbeResult {
-  confirmed: boolean;
-  varyHeaders: string[];
-  highEntropyHints: string[];
-}
-
-async function probeMySignals(domain: string): Promise<ProbeResult> {
-  try {
-    const response = await fetch(`https://${domain}/`, {
-      method: "HEAD",
-      redirect: "manual",
-      signal: AbortSignal.timeout(5000),
-    });
-
-    const criticalMs = response.headers.get("Critical-MS");
-    const acceptedMs = response.headers.get("Accepted-MS");
-    const confirmed =
-      (criticalMs !== null && criticalMs.trim().toUpperCase().split(";").includes("GPC")) ||
-      (acceptedMs !== null && acceptedMs.trim().toUpperCase().split(";").includes("GPC"));
-
-    const varyRaw = response.headers.get("Vary");
-    const varyHeaders = varyRaw
-      ? varyRaw.split(",").map((v) => v.trim()).filter(Boolean)
-      : [];
-
-    const acceptChRaw = response.headers.get("Accept-CH");
-    const highEntropyHints = acceptChRaw
-      ? acceptChRaw
-          .split(",")
-          .map((v) => v.trim())
-          .filter((hint) =>
-            HIGH_ENTROPY_HINTS.some((h) => h.toLowerCase() === hint.toLowerCase())
-          )
-      : [];
-
-    return { confirmed, varyHeaders, highEntropyHints };
-  } catch {
-    return { confirmed: false, varyHeaders: [], highEntropyHints: [] };
-  }
 }
 
 chrome.runtime.onInstalled.addListener(async function () {

--- a/src/mysignals-probe.test.ts
+++ b/src/mysignals-probe.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeMySignals } from "./mysignals-probe";
+
+function mockResponse(headers: Record<string, string>): Response {
+  return { headers: new Headers(headers) } as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("probeMySignals", () => {
+  it("confirms GPC when Critical-MS contains it and pins the request shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockResponse({ "Critical-MS": "GPC" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await probeMySignals("example.com");
+
+    expect(result).toEqual({
+      confirmed: true,
+      varyHeaders: [],
+      highEntropyHints: [],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.com/");
+    expect(init).toMatchObject({ method: "HEAD", redirect: "manual" });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns confirmed=false and empty arrays when no relevant headers are present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockResponse({ "Content-Type": "text/html" })),
+    );
+
+    const result = await probeMySignals("nogpc.example");
+
+    expect(result).toEqual({
+      confirmed: false,
+      varyHeaders: [],
+      highEntropyHints: [],
+    });
+  });
+
+  it("parses Vary and filters Accept-CH to known high-entropy hints", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse({
+          "Critical-MS": "GPC",
+          Vary: "Accept-Encoding, Cookie",
+          "Accept-CH": "Sec-CH-UA-Platform, DPR",
+        }),
+      ),
+    );
+
+    const result = await probeMySignals("example.com");
+
+    expect(result).toEqual({
+      confirmed: true,
+      varyHeaders: ["Accept-Encoding", "Cookie"],
+      highEntropyHints: ["Sec-CH-UA-Platform"],
+    });
+  });
+
+  it("returns the empty default when fetch rejects (network error / timeout)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down")),
+    );
+
+    const result = await probeMySignals("unreachable.example");
+
+    expect(result).toEqual({
+      confirmed: false,
+      varyHeaders: [],
+      highEntropyHints: [],
+    });
+  });
+});

--- a/src/mysignals-probe.ts
+++ b/src/mysignals-probe.ts
@@ -1,0 +1,52 @@
+const HIGH_ENTROPY_HINTS = [
+  "Sec-CH-UA-Platform",
+  "Sec-CH-UA-Platform-Version",
+  "Sec-CH-UA-Arch",
+  "Sec-CH-UA-Model",
+  "Sec-CH-UA-Full-Version-List",
+  "Device-Memory",
+  "Downlink",
+  "RTT",
+  "ECT",
+];
+
+export interface ProbeResult {
+  confirmed: boolean;
+  varyHeaders: string[];
+  highEntropyHints: string[];
+}
+
+export async function probeMySignals(domain: string): Promise<ProbeResult> {
+  try {
+    const response = await fetch(`https://${domain}/`, {
+      method: "HEAD",
+      redirect: "manual",
+      signal: AbortSignal.timeout(5000),
+    });
+
+    const criticalMs = response.headers.get("Critical-MS");
+    const acceptedMs = response.headers.get("Accepted-MS");
+    const confirmed =
+      (criticalMs !== null && criticalMs.trim().toUpperCase().split(";").includes("GPC")) ||
+      (acceptedMs !== null && acceptedMs.trim().toUpperCase().split(";").includes("GPC"));
+
+    const varyRaw = response.headers.get("Vary");
+    const varyHeaders = varyRaw
+      ? varyRaw.split(",").map((v) => v.trim()).filter(Boolean)
+      : [];
+
+    const acceptChRaw = response.headers.get("Accept-CH");
+    const highEntropyHints = acceptChRaw
+      ? acceptChRaw
+          .split(",")
+          .map((v) => v.trim())
+          .filter((hint) =>
+            HIGH_ENTROPY_HINTS.some((h) => h.toLowerCase() === hint.toLowerCase())
+          )
+      : [];
+
+    return { confirmed, varyHeaders, highEntropyHints };
+  } catch {
+    return { confirmed: false, varyHeaders: [], highEntropyHints: [] };
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Extract `probeMySignals` function into its own file and add unit tests for it. Update `package.json` to include `vitest` and a new `test:unit` script.